### PR TITLE
Add Shopify CLI login and theme dev scripts

### DIFF
--- a/README-seo.md
+++ b/README-seo.md
@@ -2,6 +2,21 @@
 
 This repository supports automated SEO landing pages powered by Shopify.
 
+## Quickstart
+1. Export environment variables:
+   ```bash
+   export STORE_DOMAIN=your-dev-store.myshopify.com
+   export THEME_NAME="Dev Theme"
+   ```
+2. Authenticate with Shopify CLI:
+   ```bash
+   ./scripts/shopify-login.sh
+   ```
+3. Start the local preview with hot reload:
+   ```bash
+   ./scripts/theme-dev.sh
+   ```
+
 ## Architecture
 - Content sourced from `SHEET_CSV_URL` and transformed via custom scripts.
 - Pages generated using Shopify theme extensions.

--- a/scripts/shopify-login.sh
+++ b/scripts/shopify-login.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${STORE_DOMAIN:-}" ]; then
+  echo "STORE_DOMAIN is not set" >&2
+  exit 1
+fi
+
+shopify login --store "$STORE_DOMAIN"

--- a/scripts/theme-dev.sh
+++ b/scripts/theme-dev.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${THEME_NAME:-}" ]; then
+  echo "THEME_NAME is not set" >&2
+  exit 1
+fi
+
+shopify theme dev --theme "$THEME_NAME"


### PR DESCRIPTION
## Summary
- add script for Shopify CLI store login
- add script to run `shopify theme dev` against a specific theme
- document quickstart for authenticating and starting local preview

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689cc2409c8883229a32a22128359825