### PR TITLE
Add Shopify content model registration

### DIFF
--- a/docs/content-model.md
+++ b/docs/content-model.md
@@ -1,0 +1,47 @@
+# Content Model Registration
+
+The `tools/register-content-models.mjs` script registers required content models in Shopify via the Admin GraphQL API. It is safe to run multiple times.
+
+## Metaobject Definitions
+
+### city
+- `name` – single line text
+- `state` – single line text
+- `country` – single line text
+- `blurb` – multi line text
+- `hero_image` – file reference
+
+### category_token
+- `name` – single line text
+- `slug` – single line text
+- `icon` – file reference
+- `intro` – multi line text
+
+### seo_landing
+- `city` – metaobject reference to `city`
+- `category` – metaobject reference to `category_token`
+- `h1` – single line text
+- `intro_html` – rich text
+- `body_html` – rich text
+- `faq_json` – JSON
+- `hero_image` – file reference
+- `seo_title` – single line text
+- `seo_description` – multi line text
+- `schema_extra_json` – JSON
+
+## Page Metafield
+
+Registers page metafield `custom.seo_landing_ref` of type `metaobject_reference` targeting the `seo_landing` metaobject.
+
+## Usage
+
+1. Populate a `.env` file with:
+   ```
+   ADMIN_ACCESS_TOKEN=xxx
+   STORE_DOMAIN=your-store.myshopify.com
+   ```
+2. Execute the script:
+   ```
+   node tools/register-content-models.mjs
+   ```
+3. Verify the definitions in Shopify Admin under **Content → Metaobjects** and on Pages.

--- a/tools/register-content-models.mjs
+++ b/tools/register-content-models.mjs
@@ -1,0 +1,131 @@
+import fs from 'fs';
+import path from 'path';
+
+function loadEnv() {
+  const envPath = path.resolve(process.cwd(), '.env');
+  if (fs.existsSync(envPath)) {
+    for (const line of fs.readFileSync(envPath, 'utf8').split('\n')) {
+      const match = line.match(/^([^#=]+)=(.*)$/);
+      if (match) process.env[match[1].trim()] = match[2].trim();
+    }
+  }
+}
+
+loadEnv();
+
+const { ADMIN_ACCESS_TOKEN, STORE_DOMAIN } = process.env;
+if (!ADMIN_ACCESS_TOKEN || !STORE_DOMAIN) {
+  console.error('ADMIN_ACCESS_TOKEN and STORE_DOMAIN must be set in .env');
+  process.exit(1);
+}
+
+const API_VERSION = '2024-01';
+const endpoint = `https://${STORE_DOMAIN}/admin/api/${API_VERSION}/graphql.json`;
+
+async function graphql(query, variables = {}, tries = 3) {
+  for (let attempt = 1; attempt <= tries; attempt++) {
+    try {
+      const res = await fetch(endpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Shopify-Access-Token': ADMIN_ACCESS_TOKEN,
+        },
+        body: JSON.stringify({ query, variables }),
+      });
+      const json = await res.json();
+      if (!res.ok || json.errors) {
+        throw new Error(JSON.stringify(json.errors || json));
+      }
+      return json.data;
+    } catch (err) {
+      if (attempt === tries) throw err;
+      await new Promise((r) => setTimeout(r, 1000 * attempt));
+    }
+  }
+}
+
+async function ensureMetaobjectDefinition(type, name, fields, displayNameKey) {
+  const query = `query($type: String!) {\n    metaobjectDefinitionByType(type: $type) {\n      id\n      fieldDefinitions { key }\n    }\n  }`;
+  const data = await graphql(query, { type });
+  let definitionId;
+  if (!data.metaobjectDefinitionByType) {
+    const createMutation = `mutation($definition: MetaobjectDefinitionInput!) {\n      metaobjectDefinitionCreate(definition: $definition) {\n        metaobjectDefinition { id }\n        userErrors { field message }\n      }\n    }`;
+    const createInput = { name, type, fieldDefinitions: fields, displayNameKey };
+    const res = await graphql(createMutation, { definition: createInput });
+    const errors = res.metaobjectDefinitionCreate.userErrors;
+    if (errors.length) throw new Error(JSON.stringify(errors));
+    definitionId = res.metaobjectDefinitionCreate.metaobjectDefinition.id;
+  } else {
+    definitionId = data.metaobjectDefinitionByType.id;
+    const existingKeys = data.metaobjectDefinitionByType.fieldDefinitions.map((f) => f.key);
+    const missing = fields.filter((f) => !existingKeys.includes(f.key));
+    if (missing.length) {
+      const updateMutation = `mutation($id: ID!, $fieldDefinitions: [MetaobjectFieldDefinitionInput!]!) {\n        metaobjectDefinitionUpdate(id: $id, fieldDefinitions: $fieldDefinitions) {\n          metaobjectDefinition { id }\n          userErrors { field message }\n        }\n      }`;
+      const res = await graphql(updateMutation, { id: definitionId, fieldDefinitions: missing });
+      const errors = res.metaobjectDefinitionUpdate.userErrors;
+      if (errors.length) throw new Error(JSON.stringify(errors));
+    }
+  }
+  return definitionId;
+}
+
+async function ensurePageMetafieldDefinition(seoLandingDefId) {
+  const query = `query($ownerType: MetafieldOwnerType!, $namespace: String!, $key: String!) {\n    metafieldDefinition(ownerType: $ownerType, namespace: $namespace, key: $key) { id }\n  }`;
+  const data = await graphql(query, { ownerType: 'PAGE', namespace: 'custom', key: 'seo_landing_ref' });
+  if (!data.metafieldDefinition) {
+    const mutation = `mutation($definition: MetafieldDefinitionInput!) {\n      metafieldDefinitionCreate(definition: $definition) {\n        metafieldDefinition { id }\n        userErrors { field message }\n      }\n    }`;
+    const definition = {
+      name: 'SEO Landing',
+      key: 'seo_landing_ref',
+      namespace: 'custom',
+      ownerType: 'PAGE',
+      type: 'METAOBJECT_REFERENCE',
+      validations: [{ name: 'metaobject_definition', value: seoLandingDefId }],
+    };
+    const res = await graphql(mutation, { definition });
+    const errors = res.metafieldDefinitionCreate.userErrors;
+    if (errors.length) throw new Error(JSON.stringify(errors));
+  }
+}
+
+async function main() {
+  const cityFields = [
+    { name: 'Name', key: 'name', type: 'SINGLE_LINE_TEXT_FIELD', required: true },
+    { name: 'State', key: 'state', type: 'SINGLE_LINE_TEXT_FIELD' },
+    { name: 'Country', key: 'country', type: 'SINGLE_LINE_TEXT_FIELD' },
+    { name: 'Blurb', key: 'blurb', type: 'MULTI_LINE_TEXT_FIELD' },
+    { name: 'Hero Image', key: 'hero_image', type: 'FILE_REFERENCE' },
+  ];
+  const cityDefId = await ensureMetaobjectDefinition('city', 'City', cityFields, 'name');
+
+  const categoryFields = [
+    { name: 'Name', key: 'name', type: 'SINGLE_LINE_TEXT_FIELD', required: true },
+    { name: 'Slug', key: 'slug', type: 'SINGLE_LINE_TEXT_FIELD', required: true },
+    { name: 'Icon', key: 'icon', type: 'FILE_REFERENCE' },
+    { name: 'Intro', key: 'intro', type: 'MULTI_LINE_TEXT_FIELD' },
+  ];
+  const categoryDefId = await ensureMetaobjectDefinition('category_token', 'Category Token', categoryFields, 'name');
+
+  const seoLandingFields = [
+    { name: 'City', key: 'city', type: 'METAOBJECT_REFERENCE', validations: [{ name: 'metaobject_definition', value: cityDefId }] },
+    { name: 'Category', key: 'category', type: 'METAOBJECT_REFERENCE', validations: [{ name: 'metaobject_definition', value: categoryDefId }] },
+    { name: 'H1', key: 'h1', type: 'SINGLE_LINE_TEXT_FIELD', required: true },
+    { name: 'Intro HTML', key: 'intro_html', type: 'RICH_TEXT_FIELD' },
+    { name: 'Body HTML', key: 'body_html', type: 'RICH_TEXT_FIELD' },
+    { name: 'FAQ JSON', key: 'faq_json', type: 'JSON' },
+    { name: 'Hero Image', key: 'hero_image', type: 'FILE_REFERENCE' },
+    { name: 'SEO Title', key: 'seo_title', type: 'SINGLE_LINE_TEXT_FIELD' },
+    { name: 'SEO Description', key: 'seo_description', type: 'MULTI_LINE_TEXT_FIELD' },
+    { name: 'Schema Extra JSON', key: 'schema_extra_json', type: 'JSON' },
+  ];
+  const seoLandingDefId = await ensureMetaobjectDefinition('seo_landing', 'SEO Landing', seoLandingFields, 'h1');
+
+  await ensurePageMetafieldDefinition(seoLandingDefId);
+  console.log('Content models ensured.');
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `tools/register-content-models.mjs` to register `city`, `category_token`, and `seo_landing` metaobject definitions and a page-level `custom.seo_landing_ref` metafield using Shopify Admin GraphQL with retry and idempotency
- document content models and script usage in `docs/content-model.md`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cc33429308322a50fef492c8dfb0c