### PR TITLE
Add SEO landing page template and sections

### DIFF
--- a/sections/seo-landing-faq.liquid
+++ b/sections/seo-landing-faq.liquid
@@ -1,0 +1,31 @@
+{%- assign landing = page.metafields.custom.seo_landing_ref.value -%}
+{%- if landing == blank or landing.faq_json == blank -%}
+  <div class="page-content">
+    <p>Add FAQ entries to the SEO landing metaobject to display them here.</p>
+  </div>
+{%- else -%}
+  {%- assign faqs = landing.faq_json | default: '[]' | parse_json -%}
+  {%- if faqs != blank and faqs.size > 0 -%}
+    <div class="seo-landing__faq">
+      <dl>
+        {%- for item in faqs -%}
+          {%- if item.question != blank and item.answer != blank -%}
+            <dt>{{ item.question }}</dt>
+            <dd>{{ item.answer }}</dd>
+          {%- endif -%}
+        {%- endfor -%}
+      </dl>
+    </div>
+  {%- else -%}
+    <div class="page-content">
+      <p>No FAQ entries found.</p>
+    </div>
+  {%- endif -%}
+{%- endif -%}
+
+{% schema %}
+{
+  "name": "SEO landing FAQ",
+  "settings": []
+}
+{% endschema %}

--- a/sections/seo-landing-main.liquid
+++ b/sections/seo-landing-main.liquid
@@ -1,0 +1,46 @@
+{%- assign landing = page.metafields.custom.seo_landing_ref.value -%}
+{%- if landing == blank -%}
+  <div class="page-content">
+    <p>Link a SEO landing metaobject to this page to display its content.</p>
+  </div>
+{%- else -%}
+  {%- assign heading = landing.h1 | default: page.title -%}
+  <article class="site-page seo-landing" data-template-page>
+    <header class="page-masthead">
+      <h1 class="page-title">{{ heading }}</h1>
+      {%- if landing.city != blank or landing.category != blank -%}
+        <p class="page-subtitle">
+          {%- if landing.city != blank -%}{{ landing.city }}{%- endif -%}
+          {%- if landing.city != blank and landing.category != blank -%} / {%- endif -%}
+          {%- if landing.category != blank -%}{{ landing.category }}{%- endif -%}
+        </p>
+      {%- endif -%}
+    </header>
+    {%- if landing.hero -%}
+      {%- assign hero_alt = landing.hero.alt | default: heading -%}
+      <div class="seo-landing__hero">
+        {{ landing.hero | image_url: width: 2048 | image_tag: alt: hero_alt }}
+      </div>
+    {%- endif -%}
+    {%- if landing.intro_html != blank -%}
+      <div class="seo-landing__intro rte">
+        {{ landing.intro_html }}
+      </div>
+    {%- endif -%}
+    {%- if landing.body_html != blank -%}
+      <div class="seo-landing__body rte">
+        {{ landing.body_html }}
+      </div>
+    {%- endif -%}
+    <aside class="seo-landing__related">
+      <p>Related content coming soon.</p>
+    </aside>
+  </article>
+{%- endif -%}
+
+{% schema %}
+{
+  "name": "SEO landing main",
+  "settings": []
+}
+{% endschema %}

--- a/templates/page.seo-landing.json
+++ b/templates/page.seo-landing.json
@@ -1,0 +1,1 @@
+{"sections":{"main":{"type":"seo-landing-main","settings":{}},"faq":{"type":"seo-landing-faq","settings":{}}},"order":["main","faq"]}


### PR DESCRIPTION
## Summary
- add `page.seo-landing.json` template wiring main and FAQ sections
- implement `seo-landing-main` section to render metaobject fields with fallbacks
- implement `seo-landing-faq` section to parse `faq_json` and output a definition list

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_689cc5236a508322be12012ee6037de5