### PR TITLE
feat: export Google Sheet to CSV via Apps Script

### DIFF
--- a/docs/sheets-apps-script/Code.gs
+++ b/docs/sheets-apps-script/Code.gs
@@ -1,0 +1,96 @@
+const HEADERS = [
+  'command',
+  'city_name',
+  'state',
+  'country',
+  'category_name',
+  'category_slug',
+  'page_handle',
+  'page_title',
+  'seo_title',
+  'seo_description',
+  'h1',
+  'intro_html',
+  'body_html',
+  'faq_json',
+  'hero_image_url',
+  'canonical_url',
+  'warning'
+];
+
+const SLUG_FIELDS = ['page_handle', 'category_slug'];
+const SLUG_REGEX = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const MAX_LENGTHS = {
+  page_handle: 100,
+  category_slug: 100,
+  page_title: 70,
+  seo_title: 60,
+  seo_description: 160,
+  h1: 70,
+  intro_html: 5000,
+  body_html: 20000,
+  faq_json: 8000,
+  hero_image_url: 2048,
+  canonical_url: 2048
+};
+
+function doGet(e) {
+  const ss = SpreadsheetApp.getActive();
+  const sheet = ss.getActiveSheet();
+  const values = sheet.getDataRange().getValues();
+
+  if (values.length === 0) {
+    return ContentService.createTextOutput('').setMimeType(ContentService.MimeType.CSV);
+  }
+
+  const headerRow = values[0];
+  const headerIndex = {};
+  headerRow.forEach(function(h, i) {
+    headerIndex[h] = i;
+  });
+
+  const rows = [];
+  for (let r = 1; r < values.length; r++) {
+    const row = values[r];
+    if (row.join('').trim() === '') continue; // skip empty rows
+    const record = {};
+    HEADERS.forEach(function(h) {
+      record[h] = row[headerIndex[h]] || '';
+    });
+
+    const warnings = [];
+    SLUG_FIELDS.forEach(function(field) {
+      const val = record[field];
+      if (val && !SLUG_REGEX.test(val)) {
+        warnings.push(field + ' has invalid slug');
+      }
+    });
+
+    Object.keys(MAX_LENGTHS).forEach(function(field) {
+      const val = record[field];
+      if (val && val.length > MAX_LENGTHS[field]) {
+        warnings.push(field + ' exceeds ' + MAX_LENGTHS[field] + ' chars');
+      }
+    });
+
+    record.warning = warnings.join('; ');
+    rows.push(record);
+  }
+
+  const csvRows = [HEADERS.join(',')];
+  rows.forEach(function(r) {
+    const line = HEADERS.map(function(h) {
+      return sanitize(r[h]);
+    }).join(',');
+    csvRows.push(line);
+  });
+
+  const output = csvRows.join('\n');
+  return ContentService.createTextOutput(output).setMimeType(ContentService.MimeType.CSV);
+}
+
+function sanitize(value) {
+  if (value == null) return '""';
+  const str = String(value).replace(/\r?\n/g, ' ').replace(/"/g, '""').trim();
+  return '"' + str + '"';
+}

--- a/docs/sheets-apps-script/README.md
+++ b/docs/sheets-apps-script/README.md
@@ -1,0 +1,38 @@
+# Google Sheet → Public CSV
+
+This folder contains a Google Apps Script that turns a Google Sheet into a public CSV feed.
+
+## Setup
+
+1. Open your Google Sheet.
+2. Choose **Extensions → Apps Script**.
+3. Replace the contents of `Code.gs` with the script in this directory.
+4. Press **Save**.
+
+## Deploy as Web App
+
+1. Click **Deploy → New deployment**.
+2. For *Select type*, choose **Web app**.
+3. Set **Execute as** to *Me*.
+4. Set **Who has access** to *Anyone with the link*.
+5. Click **Deploy** and authorize if prompted.
+6. Copy the Web app URL. This URL will serve the CSV when accessed with `GET`.
+
+## Sheet Requirements
+
+- The first row must use the following headers:
+
+  `command, city_name, state, country, category_name, category_slug, page_handle, page_title, seo_title, seo_description, h1, intro_html, body_html, faq_json, hero_image_url, canonical_url`
+- Additional column **warning** is added by the script.
+- The script validates `page_handle` and `category_slug` slugs (`a-z`, `0-9`, `-`).
+- Length limits are enforced for text fields. If a value exceeds its limit, the row's `warning` column explains the issue.
+
+## Usage
+
+Request the deployed URL in a browser or via `curl`:
+
+```bash
+curl https://script.google.com/macros/s/<deployment-id>/exec
+```
+
+The response is a CSV with a `warning` column. Rows with warnings should be skipped in downstream processing.


### PR DESCRIPTION
## Summary
- add Apps Script to publish Sheet data as CSV with slug and length validation
- document deployment steps for exposing sheet via web app

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cc85c7abc8322ae48cd0476898cb7