### PR TITLE
Add sheet-to-matrixify CLI and sample CSV outputs

### DIFF
--- a/data/output/metaobjects-seo_landing.csv
+++ b/data/output/metaobjects-seo_landing.csv
@@ -1,0 +1,3 @@
+Type,Identifier,Metaobject Type,Field: city,Field: category,Field: h1,Field: intro_html,Field: body_html,Field: faq_json,Field: seo_title,Field: seo_description
+metaobject,portland-plumbing,seo_landing,Portland,plumbing,Portland Plumbing Services,<p>Intro to Portland plumbing</p>,<p>Body about plumbers</p>,"[{""q"":""Q1"",""a"":""A1""}]",Portland Plumbing,Best plumbers in Portland
+metaobject,seattle-roofing,seo_landing,Seattle,roofing,Seattle Roofing Pros,<p>Intro to Seattle roofing</p>,<p>Roofing body</p>,[],Seattle Roofing,Top roofing in Seattle

--- a/data/output/pages.csv
+++ b/data/output/pages.csv
@@ -1,0 +1,3 @@
+Handle,Title,Template Suffix,Published,SEO Title,SEO Description,Metafield: custom.seo_landing_ref [metaobject_reference]
+portland-plumbing,Portland Plumbing Services,seo-landing,FALSE,Portland Plumbing,Best plumbers in Portland,seo_landing/portland-plumbing
+seattle-roofing,Seattle Roofing Pros,seo-landing,FALSE,Seattle Roofing,Top roofing in Seattle,seo_landing/seattle-roofing

--- a/data/sample-sheet.csv
+++ b/data/sample-sheet.csv
@@ -1,0 +1,3 @@
+city,category_slug,title,h1,intro_html,body_html,faq_json,seo_title,seo_description
+Portland,plumbing,Portland Plumbing Services,Portland Plumbing Services,"<p>Intro to Portland plumbing</p>","<p>Body about plumbers</p>","[{""q"":""Q1"",""a"":""A1""}]",Portland Plumbing,Best plumbers in Portland
+Seattle,roofing,Seattle Roofing Pros,Seattle Roofing Pros,"<p>Intro to Seattle roofing</p>","<p>Roofing body</p>","[]",Seattle Roofing,Top roofing in Seattle

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,25 @@
     "": {
       "name": "progseo",
       "version": "1.0.0",
+      "dependencies": {
+        "csv-parse": "^6.1.0",
+        "csv-stringify": "^6.6.0"
+      },
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/csv-parse": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-6.1.0.tgz",
+      "integrity": "sha512-CEE+jwpgLn+MmtCpVcPtiCZpVtB6Z2OKPTr34pycYYoL7sxdOkXDdQ4lRiw6ioC0q6BLqhc6cKweCVvral8yhw==",
+      "license": "MIT"
+    },
+    "node_modules/csv-stringify": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.6.0.tgz",
+      "integrity": "sha512-YW32lKOmIBgbxtu3g5SaiqWNwa/9ISQt2EcgOq0+RAIFufFp9is6tqNnKahqE5kuKvrnYAzs28r+s6pXJR8Vcw==",
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,5 +12,9 @@
     "lint": "echo 'linting'",
     "format": "echo 'formatting'",
     "test": "npm run lint"
+  },
+  "dependencies": {
+    "csv-parse": "^6.1.0",
+    "csv-stringify": "^6.6.0"
   }
 }

--- a/tools/sheet-to-matrixify.mjs
+++ b/tools/sheet-to-matrixify.mjs
@@ -1,0 +1,101 @@
+import fs from 'fs';
+import path from 'path';
+import { parse } from 'csv-parse/sync';
+import { stringify } from 'csv-stringify/sync';
+
+function loadEnv() {
+  const envPath = path.resolve(process.cwd(), '.env');
+  if (fs.existsSync(envPath)) {
+    for (const line of fs.readFileSync(envPath, 'utf8').split('\n')) {
+      const match = line.match(/^([^#=]+)=(.*)$/);
+      if (match) process.env[match[1].trim()] = match[2].trim();
+    }
+  }
+}
+
+loadEnv();
+
+const { SHEET_CSV_URL } = process.env;
+if (!SHEET_CSV_URL) {
+  console.error('SHEET_CSV_URL must be set in environment');
+  process.exit(1);
+}
+
+let limit = null;
+const args = process.argv.slice(2);
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === '--limit' && args[i + 1]) {
+    limit = parseInt(args[i + 1], 10);
+    i++;
+  }
+}
+
+function slugify(str) {
+  return str
+    .toString()
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+async function fetchCsv(url) {
+  if (/^https?:/i.test(url)) {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`Failed to fetch ${url}: ${res.status} ${res.statusText}`);
+    return await res.text();
+  }
+  const filePath = url.startsWith('file:') ? new URL(url) : url;
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+async function main() {
+  console.log(`Fetching CSV from ${SHEET_CSV_URL}`);
+  const csvText = await fetchCsv(SHEET_CSV_URL);
+  const rows = parse(csvText, { columns: true, skip_empty_lines: true });
+  console.log(`Fetched ${rows.length} rows`);
+  const selected = limit ? rows.slice(0, limit) : rows;
+  if (limit) console.log(`Limiting to ${selected.length} rows (--limit ${limit})`);
+
+  const metaobjects = [];
+  const pages = [];
+
+  for (const row of selected) {
+    const citySlug = slugify(row.city || '');
+    const identifier = `${citySlug}-${row.category_slug}`;
+    metaobjects.push({
+      Type: 'metaobject',
+      Identifier: identifier,
+      'Metaobject Type': 'seo_landing',
+      'Field: city': row.city || '',
+      'Field: category': row.category_slug || '',
+      'Field: h1': row.h1 || row.title || '',
+      'Field: intro_html': row.intro_html || '',
+      'Field: body_html': row.body_html || '',
+      'Field: faq_json': row.faq_json || '',
+      'Field: seo_title': row.seo_title || row.title || '',
+      'Field: seo_description': row.seo_description || '',
+    });
+    pages.push({
+      Handle: identifier,
+      Title: row.title || row.h1 || identifier,
+      'Template Suffix': 'seo-landing',
+      Published: 'FALSE',
+      'SEO Title': row.seo_title || row.title || '',
+      'SEO Description': row.seo_description || '',
+      'Metafield: custom.seo_landing_ref [metaobject_reference]': `seo_landing/${identifier}`,
+    });
+  }
+
+  const outDir = path.resolve('data/output');
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(path.join(outDir, 'metaobjects-seo_landing.csv'), stringify(metaobjects, { header: true }));
+  fs.writeFileSync(path.join(outDir, 'pages.csv'), stringify(pages, { header: true }));
+  console.log(`Wrote ${metaobjects.length} metaobjects to data/output/metaobjects-seo_landing.csv`);
+  console.log(`Wrote ${pages.length} pages to data/output/pages.csv`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `tools/sheet-to-matrixify.mjs` for converting a sheet to Matrixify metaobject and pages CSVs
- commit sample `data/output` CSVs generated from sample sheet
- include sample sheet and dependencies for CSV parsing

## Testing
- `npm test`
- `SHEET_CSV_URL=data/sample-sheet.csv node tools/sheet-to-matrixify.mjs --limit 1`


------
https://chatgpt.com/codex/tasks/task_e_689cc98e9c8c83229c3a4e892ee1794f