### PR TITLE
Add noindex guard for thin SEO landing pages

### DIFF
--- a/docs/noindex-guard.md
+++ b/docs/noindex-guard.md
@@ -1,0 +1,9 @@
+# Noindex guard for thin pages
+
+The `seo-landing-main` section now guards against indexing of pages with thin content.
+
+- It calculates the combined length of `intro_html` and `body_html` and compares it to a configurable threshold (default **300** characters).
+- If the combined content is shorter than the threshold, or if the page metafield `custom.noindex` is set to `true`, the section outputs `<meta name="robots" content="noindex,follow">` to prevent indexing while still following links.
+- The threshold can be adjusted in the section settings under **Noindex threshold (characters)**.
+
+This helps avoid search engines indexing pages without sufficient content.

--- a/sections/seo-landing-main.liquid
+++ b/sections/seo-landing-main.liquid
@@ -4,6 +4,20 @@
     <p>Link a SEO landing metaobject to this page to display its content.</p>
   </div>
 {%- else -%}
+  {%- assign intro_html = landing.intro_html | default: '' -%}
+  {%- assign body_html = landing.body_html | default: '' -%}
+  {%- assign content_length = intro_html | append: body_html | strip_html | strip | size -%}
+  {%- assign threshold = section.settings.noindex_threshold | default: 300 -%}
+  {%- assign noindex_flag = false -%}
+  {%- if content_length < threshold -%}
+    {%- assign noindex_flag = true -%}
+  {%- endif -%}
+  {%- if page.metafields.custom.noindex.value == true -%}
+    {%- assign noindex_flag = true -%}
+  {%- endif -%}
+  {%- if noindex_flag -%}
+    <meta name="robots" content="noindex,follow">
+  {%- endif -%}
   {%- comment -%}Structured data injection{%- endcomment -%}
   {%- assign faq_items = landing.faq_json | default: '[]' | parse_json -%}
   {%- assign faq_entity_list = '' -%}
@@ -66,6 +80,13 @@
 {% schema %}
 {
   "name": "SEO landing main",
-  "settings": []
+  "settings": [
+    {
+      "type": "number",
+      "id": "noindex_threshold",
+      "label": "Noindex threshold (characters)",
+      "default": 300
+    }
+  ]
 }
 {% endschema %}


### PR DESCRIPTION
## Summary
- compute combined intro+body length in `seo-landing-main` section
- insert `<meta name="robots" content="noindex,follow">` when content below threshold or `custom.noindex` metafield is true
- document configurable noindex guard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cd1ce6a5c83229d88dbefa5f927b8