### PR TITLE
feat: add redirects generator

### DIFF
--- a/data/output/pages-old.csv
+++ b/data/output/pages-old.csv
@@ -1,3 +1,3 @@
 Handle,Title,Template Suffix,Published,SEO Title,SEO Description,Metafield: custom.seo_landing_ref [metaobject_reference]
-portland-plumbing-experts,Portland Plumbing Services,seo-landing,FALSE,Portland Plumbing,Best plumbers in Portland,seo_landing/portland-plumbing-experts
+portland-plumbing,Portland Plumbing Services,seo-landing,FALSE,Portland Plumbing,Best plumbers in Portland,seo_landing/portland-plumbing
 seattle-roofing,Seattle Roofing Pros,seo-landing,FALSE,Seattle Roofing,Top roofing in Seattle,seo_landing/seattle-roofing

--- a/data/output/redirects.csv
+++ b/data/output/redirects.csv
@@ -1,0 +1,2 @@
+Redirect from,Redirect to,Redirect type
+/pages/portland-plumbing,/pages/portland-plumbing-experts,301

--- a/docs/redirects.md
+++ b/docs/redirects.md
@@ -1,0 +1,19 @@
+# Redirects
+
+Generate 301 redirects when page handles change.
+
+## Create redirects.csv
+
+Run:
+
+```bash
+node tools/redirects-from-diff.mjs --old data/output/pages-old.csv --new data/output/pages.csv --output data/output/redirects.csv
+```
+
+This compares the old and new `pages.csv` files and writes any handle changes to `redirects.csv`.
+
+## Import with Matrixify
+
+1. In the Matrixify app, choose **New Import → Upload File**.
+2. Upload `redirects.csv` and start the import.
+3. Each row creates a 301 redirect from the old path to the new path.

--- a/tools/redirects-from-diff.mjs
+++ b/tools/redirects-from-diff.mjs
@@ -1,0 +1,74 @@
+import fs from 'fs';
+import { parse } from 'csv-parse/sync';
+import { stringify } from 'csv-stringify/sync';
+import path from 'path';
+
+function loadCsv(file) {
+  const text = fs.readFileSync(file, 'utf8');
+  return parse(text, { columns: true, skip_empty_lines: true });
+}
+
+function usage() {
+  console.log('Usage: node tools/redirects-from-diff.mjs --old <old.csv> --new <new.csv> [--output <redirects.csv>]');
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+let oldPath = 'data/output/pages-old.csv';
+let newPath = 'data/output/pages.csv';
+let outPath = 'data/output/redirects.csv';
+
+for (let i = 0; i < args.length; i++) {
+  const arg = args[i];
+  if (arg === '--old' && args[i + 1]) {
+    oldPath = args[++i];
+  } else if (arg === '--new' && args[i + 1]) {
+    newPath = args[++i];
+  } else if (arg === '--output' && args[i + 1]) {
+    outPath = args[++i];
+  } else if (arg === '--help') {
+    usage();
+  }
+}
+
+if (!fs.existsSync(oldPath)) {
+  console.error(`Old CSV not found: ${oldPath}`);
+  process.exit(1);
+}
+if (!fs.existsSync(newPath)) {
+  console.error(`New CSV not found: ${newPath}`);
+  process.exit(1);
+}
+
+const oldRows = loadCsv(oldPath);
+const newRows = loadCsv(newPath);
+
+const oldByTitle = new Map();
+for (const row of oldRows) {
+  const title = row.Title?.trim();
+  const handle = row.Handle?.trim();
+  if (title && handle) oldByTitle.set(title, handle);
+}
+
+const redirects = [];
+for (const row of newRows) {
+  const title = row.Title?.trim();
+  const newHandle = row.Handle?.trim();
+  const oldHandle = oldByTitle.get(title);
+  if (oldHandle && newHandle && oldHandle !== newHandle) {
+    redirects.push({
+      'Redirect from': `/pages/${oldHandle}`,
+      'Redirect to': `/pages/${newHandle}`,
+      'Redirect type': '301',
+    });
+  }
+}
+
+if (!redirects.length) {
+  console.log('No handle changes detected.');
+} else {
+  const outDir = path.dirname(outPath);
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(outPath, stringify(redirects, { header: true }));
+  console.log(`Wrote ${redirects.length} redirects to ${outPath}`);
+}


### PR DESCRIPTION
## Summary
- add script to diff page CSVs and generate Matrixify-friendly redirects
- document generating and importing redirects
- provide sample old/new page CSVs and output redirects.csv

## Testing
- `node tools/redirects-from-diff.mjs`
- `npm test` *(fails: 'document' is not defined, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689cd7dc7f448322b0f01756dba0a008